### PR TITLE
resource/time_offset: Ensure base_rfc3339 is always set in Terrafrom state during creation, even if unconfigured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ ENHANCEMENTS:
 * resource/time_rotating: Add `keepers` argument
 * resource/time_static: Add `keepers` argument
 
+BUG FIXES:
+
+* resource/time_offset: Ensure `base_rfc3339` is always set in Terraform state during creation, even if unconfigured
+
 # v0.2.0
 
 BREAKING CHANGES:

--- a/internal/tftime/resource_time_offset.go
+++ b/internal/tftime/resource_time_offset.go
@@ -376,6 +376,10 @@ func resourceTimeOffsetCreate(d *schema.ResourceData, m interface{}) error {
 
 	d.SetId(timestamp.Format(time.RFC3339))
 
+	if err := d.Set("base_rfc3339", timestamp.Format(time.RFC3339)); err != nil {
+		return fmt.Errorf("error setting base_rfc3339: %s", err)
+	}
+
 	var offsetTimestamp time.Time
 
 	if v, ok := d.GetOk("offset_days"); ok {

--- a/internal/tftime/resource_time_offset_test.go
+++ b/internal/tftime/resource_time_offset_test.go
@@ -32,7 +32,7 @@ func TestAccTimeOffset_Keepers(t *testing.T) {
 				ImportState:             true,
 				ImportStateIdFunc:       testAccTimeOffsetImportStateIdFunc(resourceName),
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"base_rfc3339", "keepers"},
+				ImportStateVerifyIgnore: []string{"keepers"},
 			},
 			{
 				Config: testAccConfigTimeOffsetKeepers1("key1", "value1updated"),


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
